### PR TITLE
 Expose bits_per_coded_sample on VideoCodecContext

### DIFF
--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -93,6 +93,14 @@ cdef class VideoCodecContext(CodecContext):
             self.ptr.height = value
             self._build_format()
 
+    property bits_per_coded_sample:
+        def __get__(self):
+            return self.ptr.bits_per_coded_sample
+
+        def __set__(self, unsigned int value):
+            self.ptr.bits_per_coded_sample = value
+            self._build_format()
+
     property pix_fmt:
         """
         The pixel format's name.

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -175,6 +175,8 @@ cdef extern from "libavcodec/avcodec.h" nogil:
         int bit_rate_tolerance
         int mb_decision
 
+        int bits_per_coded_sample
+
         int global_quality
         int compression_level
 


### PR DESCRIPTION
Great to see someone taking up the torch.

`bits_per_coded_sample` needs to be set when decoding qtrle frames.

PR for issue https://github.com/PyAV-Org/PyAV/issues/1162